### PR TITLE
Spotify.Playlist.add_tracks should be a POST request

### DIFF
--- a/lib/spotify/playlist.ex
+++ b/lib/spotify/playlist.ex
@@ -280,7 +280,7 @@ defmodule Spotify.Playlist do
   """
   def add_tracks(conn, user_id, playlist_id, params \\ []) do
     url = add_tracks_url(user_id, playlist_id, params)
-    conn |> Client.put(url) |> handle_response
+    conn |> Client.post(url) |> handle_response
   end
 
   @doc"""


### PR DESCRIPTION
This function was making the request with `PUT` which replaces all the tracks in the playlist and is a different function altogether. According to the Spotify Web API docs (https://developer.spotify.com/web-api/add-tracks-to-playlist), this changes it to use a `POST` request.
