### PR TITLE
Cleaning up after myself (Mostly adds docs to Credentials module)

### DIFF
--- a/lib/spotify/client.ex
+++ b/lib/spotify/client.ex
@@ -1,32 +1,35 @@
 defmodule Spotify.Client do
   @moduledoc false
-  alias Spotify.Credentials
 
-  def get(auth, url) do
-    HTTPoison.get(url, get_headers(auth))
+  def get(conn_or_creds, url) do
+    HTTPoison.get(url, get_headers(conn_or_creds))
   end
 
-  def put(auth, url, body \\ "") do
-    HTTPoison.put(url, body, put_headers(auth))
+  def put(conn_or_creds, url, body \\ "") do
+    HTTPoison.put(url, body, put_headers(conn_or_creds))
   end
 
-  def post(auth, url, body \\ "") do
-    HTTPoison.post(url, body, post_headers(auth))
+  def post(conn_or_creds, url, body \\ "") do
+    HTTPoison.post(url, body, post_headers(conn_or_creds))
   end
 
-  def delete(auth, url) do
-    HTTPoison.delete(url, delete_headers(auth))
+  def delete(conn_or_creds, url) do
+    HTTPoison.delete(url, delete_headers(conn_or_creds))
   end
 
-  def get_headers(auth) do
-    [{"Authorization", "Bearer #{Credentials.new(auth).access_token}" }]
+  def get_headers(conn_or_creds) do
+    [{"Authorization", "Bearer #{access_token(conn_or_creds)}"}]
   end
 
-  def put_headers(auth) do
-    [ {"Authorization", "Bearer #{Credentials.new(auth).access_token}" },
-      {"Content-Type", "application/json"} ]
+  def put_headers(conn_or_creds) do
+    [{"Authorization", "Bearer #{access_token(conn_or_creds)}"},
+     {"Content-Type", "application/json"}]
   end
 
-  def post_headers(auth), do: put_headers(auth)
-  def delete_headers(auth), do: get_headers(auth)
+  defp access_token(conn_or_creds) do
+    Spotify.Credentials.new(conn_or_creds).access_token
+  end
+
+  def post_headers(conn_or_creds),   do: put_headers(conn_or_creds)
+  def delete_headers(conn_or_creds), do: get_headers(conn_or_creds)
 end

--- a/lib/spotify/cookies.ex
+++ b/lib/spotify/cookies.ex
@@ -7,13 +7,14 @@ defmodule Spotify.Cookies do
   Sets the refresh token and access token and returns the conn.
 
   ## Example:
-      Spotify.Cookies.set_cookies(conn, %Spotify.Credentials{refresh_token: rt, access_token: at})
+      credentials = %Spotify.Credentials{refresh_token: rt, access_token: at}
+      Spotify.Cookies.set_cookies(conn, credentials)
   """
-  def set_cookies(conn, auth) do
+  def set_cookies(conn, credentials) do
     conn
     |> Plug.Conn.put_status(200)
-    |> set_refresh_cookie(auth.refresh_token)
-    |> set_access_cookie(auth.access_token)
+    |> set_refresh_cookie(credentials.refresh_token)
+    |> set_access_cookie(credentials.access_token)
   end
 
   @doc """
@@ -29,7 +30,6 @@ defmodule Spotify.Cookies do
   @doc """
   Sets the access token
   """
-
   def set_access_cookie(conn, string)
   def set_access_cookie(conn, nil), do: conn
   def set_access_cookie(conn, access_token) do

--- a/lib/spotify/credentials.ex
+++ b/lib/spotify/credentials.ex
@@ -1,6 +1,52 @@
 defmodule Spotify.Credentials do
+  @moduledoc """
+  Provides a struct to hold token credentials from Spotify.
+
+  These consist of an access token, used to authenticate requests to the Spotify
+  web API, as well as a refresh token, used to request a new access token when
+  it expires.
+
+  You can use this struct in the place of a `Plug.Conn` struct anywhere in this
+  library's functions with one caveat: If you use a `Plug.Conn`, these tokens
+  will be persisted for you in browser cookies. However, if you choose to use
+  `Spotify.Credentials`, it will be your responsibility to persist this data
+  between uses of the library's functions. This is convenient if your use case
+  involves using this library in a situation where you don't have access to a
+  `Plug.Conn` or a browser/cookie system.
+
+  ## Example:
+
+      defmodule SpotifyExample do
+        @moduledoc "This example uses an `Agent` to persist the tokens"
+
+        @doc "The `Agent` is started with an empty `Credentials` struct"
+        def start_link do
+          Agent.start_link(fn -> %Spotify.Credentials{} end, name: CredStore)
+        end
+
+        defp get_creds, do: Agent.get(CredStore, &(&1))
+
+        defp put_creds(creds), do: Agent.update(CredStore, fn(_) -> creds end)
+
+        @doc "Used to link the user to Spotify to kick off the auth process"
+        def auth_url, do: Spotify.Authorization.url
+
+        @doc "`params` are passed to your callback endpoint from Spotify"
+        def authenticate(params) do
+          creds = get_creds()
+          {:ok, new_creds} = Spotify.Authentication.authenticate(creds, params)
+          put_creds(new_creds) # make sure to persist the credentials for later!
+        end
+
+        @doc "Use the credentials to access the Spotify API through the library"
+        def track(id) do
+          credentials = get_creds()
+          {:ok, track} = Track.get_track(credentials, id)
+          track
+        end
+      end
+  """
   alias Spotify.Credentials
-  alias Plug.Conn
 
   defstruct [:access_token, :refresh_token]
 
@@ -16,7 +62,9 @@ defmodule Spotify.Credentials do
     Credentials.new(access_token, refresh_token)
   end
 
-  @doc "Returns a Spotify.Credentials struct given tokens"
+  @doc """
+  Returns a Spotify.Credentials struct given tokens
+  """
   def new(access_token, refresh_token) do
     %Credentials{access_token: access_token, refresh_token: refresh_token}
   end
@@ -26,6 +74,6 @@ defmodule Spotify.Credentials do
   """
   def get_tokens_from_response(map)
   def get_tokens_from_response(response) do
-    %Spotify.Credentials{refresh_token: response["refresh_token"], access_token: response["access_token"]}
+    Credentials.new(response["access_token"], response["refresh_token"])
   end
 end

--- a/lib/spotify/credentials.ex
+++ b/lib/spotify/credentials.ex
@@ -7,8 +7,9 @@ defmodule Spotify.Credentials do
   @doc """
   Returns a Spotify.Credentials struct from either a Plug.Conn or a Spotify.Credentials struct
   """
-  def new(auth = %Credentials{}), do: auth
-  def new(conn = %Conn{}) do
+  def new(conn_or_credentials)
+  def new(creds = %Credentials{}), do: creds
+  def new(conn = %Plug.Conn{}) do
     conn = Plug.Conn.fetch_cookies(conn)
     access_token = conn.cookies["spotify_access_token"]
     refresh_token = conn.cookies["spotify_refresh_token"]

--- a/test/cookies_test.exs
+++ b/test/cookies_test.exs
@@ -1,7 +1,7 @@
 defmodule SpotifyCookiesTest do
   use ExUnit.Case
   doctest Spotify.Cookies
-  alias Spotify.{Cookies, Credentials}
+  alias Spotify.Cookies
 
   test "#set_refresh_cookie" do
     conn =

--- a/test/credentials_test.exs
+++ b/test/credentials_test.exs
@@ -3,10 +3,10 @@ defmodule Spotify.CredentialsTest do
 
   @atoken "access_token"
   @rtoken "refresh_token"
-  @auth %Spotify.Credentials{access_token: @atoken, refresh_token: @rtoken}
+  @creds %Spotify.Credentials{access_token: @atoken, refresh_token: @rtoken}
 
   test "new/2 returns a Spotify.Credentials struct when given tokens" do
-    assert @auth == Spotify.Credentials.new(@atoken, @rtoken)
+    assert @creds == Spotify.Credentials.new(@atoken, @rtoken)
   end
 
   describe "new/1 returns a Spotify.Credentials struct" do
@@ -15,16 +15,16 @@ defmodule Spotify.CredentialsTest do
               |> Plug.Conn.fetch_cookies
               |> Plug.Conn.put_resp_cookie("spotify_access_token",  @atoken)
               |> Plug.Conn.put_resp_cookie("spotify_refresh_token", @rtoken)
-      assert @auth == Spotify.Credentials.new(conn)
+      assert @creds == Spotify.Credentials.new(conn)
     end
 
     test "when given a Spotify.Credentials struct" do
-      assert @auth == Spotify.Credentials.new(@auth)
+      assert @creds == Spotify.Credentials.new(@creds)
     end
   end
 
   test "get_tokens_from_response/1 returns a Spotify.Credentials struct" do
     response = %{"access_token" => @atoken, "refresh_token" => @rtoken}
-    assert @auth == Spotify.Credentials.get_tokens_from_response(response)
+    assert @creds == Spotify.Credentials.get_tokens_from_response(response)
   end
 end


### PR DESCRIPTION
So, I realized that I left almost no documentation for `Spotify.Credentials` and that it might be helpful to do so and also to provide an example. While I was at it, I cleaned up a few other things that I missed the first time around (like leaving some variables named `auth` instead of `credentials` or `conn_or_creds`. Now those functions are slightly more clear as to their usage.
