### PR TITLE
Fixes an inifinite loop in Spotify.Playlist

### DIFF
--- a/lib/spotify/playlist.ex
+++ b/lib/spotify/playlist.ex
@@ -193,7 +193,7 @@ defmodule Spotify.Playlist do
   def get_playlist_tracks(conn, user_id, playlist_id, params \\ []) do
     alias Spotify.Playlist.Track, as: Track
 
-    url = get_playlist_tracks(user_id, playlist_id, params)
+    url = get_playlist_tracks_url(user_id, playlist_id, params)
     conn |> Client.get(url) |> Track.handle_response
   end
 


### PR DESCRIPTION
Fixes an infinite loop caused by calling the wrong function (itself) in `get_playlist_tracks` instead of `get_playlist_tracks_url`. I checked the rest of the module and didn't see any more of these.
