### PR TITLE
Mapping multiple types when searching

### DIFF
--- a/lib/spotify/search.ex
+++ b/lib/spotify/search.ex
@@ -40,41 +40,29 @@ defmodule Spotify.Search do
   Implements the hook required by the `Responder` behaviour
   """
   def build_response(body) do
-    {items, _rest} = body
-                     |> Map.take(@keys)
-                     |> Map.to_list
-                     |> Enum.flat_map_reduce([], fn({key, data}, acc) ->
-                       {map_to_struct(key, data["items"]), acc}
-                     end)
-    Paging.response(body, items)
+    body
+    |> Map.take(@keys)
+    |> Map.to_list
+    |> Enum.flat_map_reduce([], &reducer/2)
+    |> build_paging(body)
   end
 
+  @doc false
+  def reducer({key, data}, acc), do: {map_to_struct(key, data["items"]), acc}
+
+  @doc false
+  def build_paging({items, _rest}, body), do: Paging.response(body, items)
+
+  @doc false
   def map_to_struct("artists", artists), do: Artist.build_artists(artists)
+
+  @doc false
   def map_to_struct("tracks", tracks), do: Track.build_tracks(tracks)
+
+  @doc false
   def map_to_struct("playlists", playlists), do: Playlist.build_playlists(playlists)
+
+  @doc false
   def map_to_struct("albums", albums), do: Enum.map(albums, &to_struct(Album, &1))
 
-  @doc false
-  def build_albums(body, albums) do
-    albums = Enum.map(albums, &to_struct(Album, &1))
-    Paging.response(body, albums)
-  end
-
-  @doc false
-  def build_artists(body, artists) do
-    artists = Artist.build_artists(artists)
-    Paging.response(body, artists)
-  end
-
-  @doc false
-  def build_playlists(body, playlists) do
-    playlists = Playlist.build_playlists(playlists)
-    Paging.response(body, playlists)
-  end
-
-  @doc false
-  def build_tracks(body, tracks) do
-    tracks = Track.build_tracks(tracks)
-    Paging.response(body, tracks)
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Spotify.Mixfile do
 
   def project do
     [app: :spotify_ex,
-     version: "2.0.4",
+     version: "2.0.5",
      elixir: "~> 1.3",
      description: description,
      package: package,

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -38,5 +38,22 @@ defmodule SearchTest do
 
       assert actual == expected
     end
+
+    test "responds with albums, artists, tracks and playists" do
+      response = %{ "artists" => %{"items" => [ %{"name" => "artist"} ] },
+                    "tracks" => %{"items" => [ %{"name" => "track"} ] },
+                    "playlists" => %{"items" => [ %{"name" => "playlist"} ] },
+                    "albums" => %{"items" => [ %{"name" => "album" }]}
+                  }
+
+      expected = %Paging{items: [%Artist{name: "artist"},
+                                 %Track{name: "track"},
+                                 %Playlist{name: "playlist"},
+                                 %Album{name: "album"}
+      ]}
+      actual = Search.build_response(response)
+
+      assert actual == expected
+    end
   end
 end

--- a/test/search_test.exs
+++ b/test/search_test.exs
@@ -46,11 +46,10 @@ defmodule SearchTest do
                     "albums" => %{"items" => [ %{"name" => "album" }]}
                   }
 
-      expected = %Paging{items: [%Artist{name: "artist"},
-                                 %Track{name: "track"},
+      expected = %Paging{items: [%Album{name: "album"},
+                                 %Artist{name: "artist"},
                                  %Playlist{name: "playlist"},
-                                 %Album{name: "album"}
-      ]}
+                                 %Track{name: "track"}]}
       actual = Search.build_response(response)
 
       assert actual == expected


### PR DESCRIPTION
When you make a search and add multiple types (album, artist, playlist, and track) the build response from Search module only catch one case. build_response function from Search module, was modified to convert all types and to add Paging