### PR TITLE
Add pagination options to Playlist API calls

### DIFF
--- a/lib/spotify/album.ex
+++ b/lib/spotify/album.ex
@@ -25,7 +25,7 @@ defmodule Spotify.Album do
     album_type artists available_markets
     copyrights external_ids external_urls
     genres href id images name popularity
-    release_date release_date_precision tracks type]a
+    release_date release_date_precision tracks type label]a
 
   @doc """
   Get Spotify catalog information for a single album.

--- a/lib/spotify/paging.ex
+++ b/lib/spotify/paging.ex
@@ -11,7 +11,7 @@ defmodule Paging do
   Paging Struct. The Spotify API returns collections in a Paging
   object, with the collection in the `items` key.
   """
-  defstruct ~w[ href items limit next offset previous total cursor]a
+  defstruct ~w[href items limit next offset previous total cursor]a
 
   @doc """
     Takes the response body from an API call that returns a collection.

--- a/lib/spotify/playlist.ex
+++ b/lib/spotify/playlist.ex
@@ -135,7 +135,17 @@ defmodule Spotify.Playlist do
   ** Optional Params: `limit`, `offset`
 
       Spotify.Playlist.get_users_playlists(conn, "123", q: "foo", limit: 5)
-      # => {:ok, %{ items: [%Spotify.Playlist{..} ...]}}
+      # => {:ok, %{ 
+      #     cursor: nil, 
+      #     href: .., 
+      #     items: [%Spotify.Playlist{..} ...], 
+      #     limit: 20, 
+      #     next: nil, 
+      #     offset: 0, 
+      #     previous: nil,
+      #     total: 20
+      #   }
+      # }
   """
   def get_users_playlists(conn, user_id, params \\ []) do
     url = get_users_playlists_url(user_id, params)

--- a/lib/spotify/playlist.ex
+++ b/lib/spotify/playlist.ex
@@ -434,15 +434,27 @@ defmodule Spotify.Playlist do
   """
   def build_response(body) do
     case body do
-      %{"playlists" => playlists} -> %Paging{items: build_playlists(playlists["items"])}
-      %{"items" => items} -> %Paging{items: build_playlists(items)}
+      (%{"items" => _items} = response) -> build_paged_response(response)
+      %{"playlists" => playlists} -> build_paged_response(playlists)
       _ -> to_struct(__MODULE__, body)
     end
+  end
+
+  @doc false
+  defp build_paged_response(response) do
+    %Paging{
+      href: response["href"],
+      items: build_playlists(response["items"]),
+      limit: response["limit"],
+      next: response["next"],
+      offset: response["offset"],
+      previous: response["previous"],
+      total: response["total"]
+    }
   end
 
   @doc false
   def build_playlists(playlists) do
     Enum.map(playlists, &to_struct(__MODULE__, &1))
   end
-
 end

--- a/test/album_test.exs
+++ b/test/album_test.exs
@@ -4,8 +4,8 @@ defmodule Album do
   alias Spotify.{Album, Track}
 
   test "%Spotify.Album{}" do
-    expected = ~w[ album_type artists available_markets copyrights external_ids
-      external_urls genres href id images name popularity release_date
+    expected = ~w[album_type artists available_markets copyrights external_ids
+      external_urls genres href id images label name popularity release_date
       release_date_precision tracks type]a
 
     actual = %Album{} |> Map.from_struct |> Map.keys

--- a/test/paging_test.exs
+++ b/test/paging_test.exs
@@ -2,7 +2,7 @@ defmodule PagingTest do
   use ExUnit.Case
 
   test "%Paging{}" do
-    expected = ~w[ cursor href items limit next offset previous total ]a
+    expected = ~w[cursor href items limit next offset previous total]a
     actual = %Paging{} |> Map.from_struct |> Map.keys
 
     assert actual == expected

--- a/test/playlist_test.exs
+++ b/test/playlist_test.exs
@@ -5,16 +5,32 @@ defmodule PlaylistTest do
   describe "build_response/1" do
     test "the API returns a playlist element" do
       actual = Playlist.build_response(response_body_with_playlist_element())
-      playlists = [%Playlist{name: "foo"}, %Playlist{name: "bar"}]
-      expected = %Paging{items: playlists}
+      
+      expected = %Paging{
+        href: "https://api.spotify.com/v1/users/anuser/playlists?offset=0&limit=20",
+        items: [%Playlist{name: "foo"}, %Playlist{name: "bar"}],
+        limit: 20,
+        next: "https://api.spotify.com/v1/users/anuser/playlists?offset=20&limit=20",
+        offset: 0,
+        previous: nil,
+        total: 62
+      }
 
       assert actual == expected
     end
 
     test "the API returns a items collections without a playlists root" do
       actual = Playlist.build_response(response_body_without_playlist_element())
-      playlists = [%Playlist{name: "foo"}, %Playlist{name: "bar"}]
-      expected = %Paging{items: playlists}
+      
+      expected = %Paging{
+        href: "https://api.spotify.com/v1/users/anuser/playlists?offset=0&limit=20",
+        items: [%Playlist{name: "foo"}, %Playlist{name: "bar"}],
+        limit: 20,
+        next: "https://api.spotify.com/v1/users/anuser/playlists?offset=20&limit=20",
+        offset: 0,
+        previous: nil,
+        total: 62
+      }
 
       assert actual == expected
     end
@@ -31,13 +47,26 @@ defmodule PlaylistTest do
   def response_body_with_playlist_element do
     %{
       "playlists" => %{
-        "items" => [%{ "name" => "foo" }, %{ "name" => "bar" } ]
+        "href" => "https://api.spotify.com/v1/users/anuser/playlists?offset=0&limit=20",
+        "items" => [%{ "name" => "foo" }, %{ "name" => "bar" } ],
+        "limit" => 20,
+        "next" => "https://api.spotify.com/v1/users/anuser/playlists?offset=20&limit=20",
+        "offset" => 0,
+        "previous" => nil,
+        "total" => 62
       }
     }
   end
 
   def response_body_without_playlist_element do
-    %{"items" => [%{ "name" => "foo" }, %{ "name" => "bar" } ]}
+    %{
+      "href" => "https://api.spotify.com/v1/users/anuser/playlists?offset=0&limit=20",
+      "items" => [%{ "name" => "foo" }, %{ "name" => "bar" } ],
+      "limit" => 20,
+      "next" => "https://api.spotify.com/v1/users/anuser/playlists?offset=20&limit=20",
+      "offset" => 0,
+      "previous" => nil,
+      "total" => 62
+     }
   end
-
 end


### PR DESCRIPTION
This PR adds the missing pagination options (href, next, previous and etc) present in the Spotify API calls related to playlists.