### PR TITLE
Use downcase to match `retry-after` header

### DIFF
--- a/lib/spotify/responder.ex
+++ b/lib/spotify/responder.ex
@@ -24,7 +24,7 @@ defmodule Spotify.Responder do
           ) do
         {retry_after, ""} =
           headers
-          |> Enum.find(&(Kernel.elem(&1, 0) == "Retry-After"))
+          |> Enum.find(fn {key, value} -> String.downcase(key) == "retry-after" end)
           |> Kernel.elem(1)
           |> Integer.parse()
 


### PR DESCRIPTION
The header is now [being returned in lower case by the Spotify API](https://github.com/spotify/web-api/issues/1267), let's
make it downcase anyway to ensure we will always match the correct
header.