### PR TITLE
Adding handling for HTTPoison.Error return values within Spotify.Responder

### DIFF
--- a/lib/spotify/responder.ex
+++ b/lib/spotify/responder.ex
@@ -41,6 +41,10 @@ defmodule Spotify.Responder do
 
         {:ok, response}
       end
+
+      def handle_response({:error, %HTTPoison.Error{reason: reason}}) do
+        {:error, reason}
+      end
     end
   end
 end

--- a/test/spotify/responder_test.exs
+++ b/test/spotify/responder_test.exs
@@ -38,6 +38,11 @@ defmodule Spotify.ResponderTest do
       assert GenericMock.some_endpoint(too_many_requests_error(99, "Retry-After")) ==
                too_many_requests_error_expect()
     end
+
+    test "with arbitrary HTTPoison error" do
+      assert GenericMock.some_endpoint({:error, %HTTPoison.Error{reason: :timeout}}) ==
+               {:error, :timeout}
+    end
   end
 
   defp too_many_requests_error(retry_after_value, header_name) do


### PR DESCRIPTION
Currently, the clauses for "handle_response/2" within Spotify.Responder only handle valid HTTP responses from requests, but not HTTP errors (generally caused by some network or SSL issue). For example, if I call "Spotify.Profile.me(my_credentials)" while not connected to the internet, I get a FunctionClauseError.

I added an extra clause to match the behavior of AuthenticationClient.post/1.