### PR TITLE
Modified 'build_response/2' within 'Spotify.Library' to return a fully populated Paging struct

### DIFF
--- a/lib/spotify/library.ex
+++ b/lib/spotify/library.ex
@@ -131,14 +131,28 @@ defmodule Spotify.Library do
   """
   def build_response(body) do
     case body do
-      %{"items" => tracks} -> build_tracks(tracks)
+      %{"items" => _tracks} = response -> build_paged_response(response)
       booleans_or_error -> booleans_or_error
     end
   end
 
+  @doc false
+  defp build_paged_response(response) do
+    %Paging{
+      href: response["href"],
+      items: build_tracks(response["items"]),
+      limit: response["limit"],
+      next: response["next"],
+      offset: response["offset"],
+      previous: response["previous"],
+      total: response["total"]
+    }
+  end
+
+  @doc false
   def build_tracks(tracks) do
-    tracks = Enum.map(tracks, fn %{"track" => items} -> items end)
-    tracks = Track.build_tracks(tracks)
-    %Paging{items: tracks}
+    tracks
+    |> Enum.map(fn %{"track" => items} -> items end)
+    |> Track.build_tracks()
   end
 end

--- a/test/spotify/library_test.exs
+++ b/test/spotify/library_test.exs
@@ -11,7 +11,16 @@ defmodule Spotify.LibraryTest do
     test "returns a collection of Spotify.Tracks" do
       response = tracks_response()
 
-      expected = %Paging{items: [%Track{name: "foo"}, %Track{name: "bar"}]}
+      expected = %Paging{
+        href: "https://api.spotify.com/v1/me/tracks?offset=0&limit=20",
+        items: [%Track{name: "foo"}, %Track{name: "bar"}],
+        limit: 20,
+        next: "https://api.spotify.com/v1/me/tracks?offset=20&limit=20",
+        offset: 0,
+        previous: nil,
+        total: 62
+      }
+
       actual = Library.build_response(response)
 
       assert actual == expected
@@ -27,12 +36,18 @@ defmodule Spotify.LibraryTest do
     end
   end
 
-  defp tracks_response do
+  def tracks_response do
     %{
+      "href" => "https://api.spotify.com/v1/me/tracks?offset=0&limit=20",
       "items" => [
         %{"track" => %{"name" => "foo"}},
         %{"track" => %{"name" => "bar"}}
-      ]
+      ],
+      "limit" => 20,
+      "next" => "https://api.spotify.com/v1/me/tracks?offset=20&limit=20",
+      "offset" => 0,
+      "previous" => nil,
+      "total" => 62
     }
   end
 end


### PR DESCRIPTION
Revisiting [previously closed PR](https://github.com/jsncmgs1/spotify_ex/pull/40/files)