### PR TITLE
Fix Album.new_releases API

### DIFF
--- a/lib/spotify/album.ex
+++ b/lib/spotify/album.ex
@@ -311,5 +311,11 @@ defmodule Spotify.Album do
   end
 
   @doc false
-  def build_albums(albums), do: Enum.map(albums, &build_album/1)
+  def build_albums(albums) when is_list(albums), do: Enum.map(albums, &build_album/1)
+
+  def build_albums(albums) when is_map(albums) do
+    paging = to_struct(Paging, albums)
+    new_releases = Enum.map(paging.items, &to_struct(Album, &1))
+    Map.put(paging, :items, new_releases)
+  end
 end

--- a/test/spotify/album_test.exs
+++ b/test/spotify/album_test.exs
@@ -37,6 +37,13 @@ defmodule Spotify.AlbumTest do
 
       assert actual == expected
     end
+
+    test "when a collection of new releases is requested" do
+      actual = Album.build_response(new_releases())
+      expected = %Paging{href: "link", items: [%Album{name: "foo"}]}
+
+      assert actual == expected
+    end
   end
 
   def tracks_response do
@@ -64,6 +71,15 @@ defmodule Spotify.AlbumTest do
       "tracks" => %{
         # tracks is a paging object, the actual tracks are in
         # the items key
+        "items" => [%{"name" => "foo"}]
+      }
+    }
+  end
+
+  def new_releases do
+    %{
+      "albums" => %{
+        "href" => "link",
         "items" => [%{"name" => "foo"}]
       }
     }


### PR DESCRIPTION
Hi :wave: 
when trying out the API `Album.new_releases` i got this error 

```
** (BadMapError) expected a map, got: {"href", "https://api.spotify.com/v1/browse/new-releases?offset=0&limit=20"}
    (stdlib 3.16.1) :maps.find("__struct__", {"href", "https://api.spotify.com/v1/browse/new-releases?offset=0&limit=20"})
    (spotify_ex 2.2.0) lib/spotify/helpers.ex:17: anonymous fn/3 in Spotify.Helpers.to_struct/2
    (elixir 1.12.0) lib/enum.ex:2356: Enum."-reduce/3-lists^foldl/2-0-"/3
    (spotify_ex 2.2.0) lib/spotify/album.ex:306: Spotify.Album.build_album/1
    (elixir 1.12.0) lib/enum.ex:1557: anonymous fn/3 in Enum.map/2
    (stdlib 3.16.1) maps.erl:410: :maps.fold_1/3
    (elixir 1.12.0) lib/enum.ex:2368: Enum.map/2
    (spotify_ex 2.2.0) lib/spotify/album.ex:20: Spotify.Album.handle_response/1

```
This PR should fix the response of new_releases API 