### PR TITLE
fix: improve handle_response for text/plain body case

### DIFF
--- a/test/spotify/responder_test.exs
+++ b/test/spotify/responder_test.exs
@@ -19,9 +19,27 @@ defmodule Spotify.ResponderTest do
       assert GenericMock.some_endpoint(success_empty_body()) == :ok
     end
 
-    test "with 200/201 status and a body" do
+    test "with 200/201 status and JSON content-type with body" do
       expected = {:ok, %Spotify.Playlist{name: "foo"}}
-      assert GenericMock.some_endpoint(success_with_body()) == expected
+      assert GenericMock.some_endpoint(success_with_json_body()) == expected
+    end
+
+    test "with 200/201 status and JSON content-type with charset parameter" do
+      expected = {:ok, %Spotify.Playlist{name: "foo"}}
+      assert GenericMock.some_endpoint(success_with_json_body_and_charset()) == expected
+    end
+
+    test "with 200/201 status and non-JSON content-type" do
+      assert GenericMock.some_endpoint(success_with_text_body()) == :ok
+    end
+
+    test "with 200/201 status and no content-type header" do
+      assert GenericMock.some_endpoint(success_with_no_content_type()) == :ok
+    end
+
+    test "with 200/201 status and case-insensitive content-type header" do
+      expected = {:ok, %Spotify.Playlist{name: "foo"}}
+      assert GenericMock.some_endpoint(success_with_uppercase_content_type()) == expected
     end
 
     test "with 400 status and a body" do
@@ -67,10 +85,46 @@ defmodule Spotify.ResponderTest do
   end
 
   defp success_empty_body do
-    {:ok, %HTTPoison.Response{body: "", status_code: 200}}
+    {:ok, %HTTPoison.Response{body: "", status_code: 200, headers: []}}
   end
 
-  defp success_with_body do
-    {:ok, %HTTPoison.Response{body: Poison.encode!(%{name: "foo"}), status_code: 200}}
+  defp success_with_json_body do
+    {:ok, %HTTPoison.Response{
+      body: Poison.encode!(%{name: "foo"}),
+      status_code: 200,
+      headers: [{"Content-Type", "application/json"}]
+    }}
+  end
+
+  defp success_with_json_body_and_charset do
+    {:ok, %HTTPoison.Response{
+      body: Poison.encode!(%{name: "foo"}),
+      status_code: 200,
+      headers: [{"Content-Type", "application/json; charset=utf-8"}]
+    }}
+  end
+
+  defp success_with_text_body do
+    {:ok, %HTTPoison.Response{
+      body: "Plain text response",
+      status_code: 200,
+      headers: [{"Content-Type", "text/plain"}]
+    }}
+  end
+
+  defp success_with_no_content_type do
+    {:ok, %HTTPoison.Response{
+      body: "Some response without content type",
+      status_code: 200,
+      headers: []
+    }}
+  end
+
+  defp success_with_uppercase_content_type do
+    {:ok, %HTTPoison.Response{
+      body: Poison.encode!(%{name: "foo"}),
+      status_code: 200,
+      headers: [{"CONTENT-TYPE", "application/json"}]
+    }}
   end
 end


### PR DESCRIPTION
Some Spotify API endpoints can return a non-JSON-like, but valid body without an `application/json` header, however, `spotify_ex` attempts to decode any response with `Poison.decode!()`, which causes errors

```
[lib/spotify/client.ex:9: Spotify.Client.put/3]
HTTPoison.put(url, body, put_headers(conn_or_creds)) #=> {:ok,
 %HTTPoison.Response{
   status_code: 200,
   body: "EkJbtxDxPnQzrcHfR59mihtOKvc",
   headers: [
     {"cache-control", "private, max-age=0"},
     {"x-robots-tag", "noindex, nofollow"},
     {"access-control-allow-origin", "*"},
     {"access-control-allow-headers",
      "Accept, App-Platform, Authorization, Content-Type, Origin, Retry-After, Spotify-App-Version, X-Cloud-Trace-Context, client-token, content-access-token"},
     {"access-control-allow-methods", "GET, POST, OPTIONS, PUT, DELETE, PATCH"},
     {"access-control-allow-credentials", "true"},
     {"access-control-max-age", "604800"},
     {"Content-Length", "27"},
     {"strict-transport-security", "max-age=31536000"},
     {"x-content-type-options", "nosniff"},
     {"alt-svc", "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"},
     {"date", "Sat, 19 Jul 2025 21:39:06 GMT"},
     {"server", "envoy"},
     {"Via", "HTTP/2 edgeproxy, 1.1 google"},
     {"Alt-Svc", "h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000"}
   ],
   request_url: "https://api.spotify.com/v1/me/player/play"
 }}

[error] GenServer #PID<0.1131.0> terminating
** (Poison.SyntaxError) Unexpected token at position 0: E
    (poison 3.1.0) lib/poison/parser.ex:57: Poison.Parser.parse!/2
    (poison 3.1.0) lib/poison.ex:83: Poison.decode!/2
    (spotify_ex 2.2.1) lib/spotify/player.ex:8: Spotify.Player.handle_response/1
    (songy 0.1.0) lib/songy/boundary/spotify.ex:37: Songy.Boundary.Spotify.start_playback/2
    (songy 0.1.0) lib/songy_web/channels/room_channel.ex:98: SongyWeb.RoomChannel.handle_in/3
    (phoenix 1.8.0-rc.3) lib/phoenix/channel/server.ex:322: Phoenix.Channel.Server.handle_info/2
    (stdlib 6.2.2) gen_server.erl:2345: :gen_server.try_handle_info/3
    (stdlib 6.2.2) gen_server.erl:2433: :gen_server.handle_msg/6
    (stdlib 6.2.2) proc_lib.erl:329: :proc_lib.init_p_do_apply/3
Last message: %Phoenix.Socket.Message{topic: "room:1wA_2mTV", event: "start_playback", payload: %{}, ref: "7", join_ref: "3"}
```

this can be fixed by treating successful responses without a header `application/json` as a valid string